### PR TITLE
DEV: Fix undefined method id for nil class

### DIFF
--- a/spec/serializers/current_user_serializer_spec.rb
+++ b/spec/serializers/current_user_serializer_spec.rb
@@ -7,10 +7,9 @@ describe CurrentUserSerializer, type: :serializer do
     described_class.new(user, scope: guardian, root: false)
   end
 
-  let(:guardian) { Guardian.new }
-
   describe "CurrentUserSerializer extension" do
-    fab!(:user) { Fabricate(:user) }
+    let!(:user) { Fabricate(:user) }
+    let!(:guardian) { Guardian.new(user) }
 
     it "includes can_use_templates in serialization" do
       json = serializer.as_json


### PR DESCRIPTION
In the "plugins backend" github build job on PR [#19406](https://github.com/discourse/discourse/pull/19406) I'm currently
getting an undefined method id for a nil user that is showing up
initiated from this plugin. I think it has to do with the user not being
passed into the guardian. Let's see if this fixes it.
