### PR TITLE
REVERT: "DEV: Use 'class' instead of '@class' for TextField (#32)"

### DIFF
--- a/assets/javascripts/discourse/templates/components/templates-filterable-list.hbs
+++ b/assets/javascripts/discourse/templates/components/templates-filterable-list.hbs
@@ -8,7 +8,7 @@
       />
     {{/if}}
     <TextField
-      class="templates-filter"
+      @class="templates-filter"
       @value={{listFilter}}
       placeholder={{i18n "templates.filter_hint"}}
     />


### PR DESCRIPTION
This reverts commit e47c47c04d58b3abb858715d6a9453c764c9763c.

Didn't fix deprecation I thought it might.