### PR TITLE
DEV: ensures modal has finished loading

### DIFF
--- a/spec/system/page_objects/modals/insert_template.rb
+++ b/spec/system/page_objects/modals/insert_template.rb
@@ -10,7 +10,11 @@ module PageObjects
       end
 
       def open?
-        super && has_css?(".d-templates-modal")
+        super && has_css?(".d-templates-modal") && finished_loading?
+      end
+
+      def finished_loading?
+        has_no_css?(".d-templates-modal .spinner")
       end
 
       def select_template(id)


### PR DESCRIPTION
It's unclear if it could be the cause of a timeout, but it seems like a better change to make and might give us a better error.

`<DTemplates::FilterableList>` has `loading=true` by default, so we are sure that on insert the spinner is showing. This commit ensures the spinner is gone before we consider the modal truly opened.