### PR TITLE
DEV: Fix specs by using `use_service` option

### DIFF
--- a/spec/system/chat_composer_spec.rb
+++ b/spec/system/chat_composer_spec.rb
@@ -14,11 +14,15 @@ RSpec.describe "Inserting templates in the chat composer", type: :system do
   end
 
   fab!(:channel_1) { Fabricate(:chat_channel) }
-  fab!(:message_1) { Fabricate(:chat_message, user: current_user, chat_channel: channel_1) }
-  fab!(:message_2) do
-    Fabricate(:chat_message, chat_channel: channel_1, user: other_user, in_reply_to: message_1)
+  fab!(:message_1) do
+    Fabricate(:chat_message, user: current_user, chat_channel: channel_1, use_service: true)
   end
-  fab!(:message_3) { Fabricate(:chat_message, user: other_user, chat_channel: channel_1) }
+  fab!(:message_2) do
+    Fabricate(:chat_message, user: other_user, in_reply_to: message_1, use_service: true)
+  end
+  fab!(:message_3) do
+    Fabricate(:chat_message, user: other_user, chat_channel: channel_1, use_service: true)
+  end
 
   let(:chat_page) { PageObjects::Pages::Chat.new }
   let(:channel_page) { PageObjects::Pages::ChatChannel.new }


### PR DESCRIPTION
PR https://github.com/discourse/discourse/pull/23222 introduced a new `use_service` option for the `chat_message` fabricator allowing to create a message by using the proper service under the hood.
This broke this plugin specs, the solution is to simply use the new option in system specs.