### PR TITLE
FIX: Move plugin into own setting category

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,4 +1,9 @@
 en:
+  admin_js:
+    admin:
+      site_settings:
+        categories:
+          discourse_templates: "Discourse Templates"
   js:
     keyboard_shortcuts_help:
       templates:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,4 @@
-plugins:
+discourse_templates:
   discourse_templates_enabled:
     default: true
     client: true


### PR DESCRIPTION
Instead of using plugins: as the root, which just lumps this
plugin's settings into the Plugins site setting category, we
need to give it a distinct root that matches the plugin name.
