### PR TITLE
UX: fix button container to avoid mobile overflow

### DIFF
--- a/assets/stylesheets/discourse-templates.scss
+++ b/assets/stylesheets/discourse-templates.scss
@@ -124,9 +124,10 @@
 
 .template-topic-controls {
   display: flex;
-  justify-content: right;
-  width: calc(
-    var(--topic-body-width) + var(--topic-body-width-padding) * 2 + 45px
-  );
+  flex-wrap: wrap;
   gap: 0.5em;
+  margin-bottom: 1em;
+  .mobile-view & {
+    font-size: var(--font-down-1);
+  }
 }


### PR DESCRIPTION
Fixes this issue on mobile:

![Screenshot 2023-10-30 at 12 55 47 PM](https://github.com/discourse/discourse-templates/assets/1681963/3a59cc6c-4c63-4e30-b06a-d2abe7513e39)


Now the buttons will be aligned-left:

![Screenshot 2023-10-30 at 12 53 46 PM](https://github.com/discourse/discourse-templates/assets/1681963/be89ba82-9c77-4694-b180-27ce8ba8fb38)

and worst-case, they can wrap on tiny devices instead of overflowing:

![Screenshot 2023-10-30 at 12 54 21 PM](https://github.com/discourse/discourse-templates/assets/1681963/05749042-2105-455f-9ab2-4f9929063e51)



This also changes the positioning on desktop...

Before:
![Screenshot 2023-10-30 at 12 57 24 PM](https://github.com/discourse/discourse-templates/assets/1681963/37a31030-b2c4-44ab-ace0-c8c7dc071010)


After: 
![Screenshot 2023-10-30 at 12 57 45 PM](https://github.com/discourse/discourse-templates/assets/1681963/e8833d8e-d80a-4c7b-9c97-139bdfcedd1c)

