### PR TITLE
FIX: Do not nest html with parents css class

### DIFF
--- a/assets/javascripts/discourse/connectors/editor-preview/d-templates.hbs
+++ b/assets/javascripts/discourse/connectors/editor-preview/d-templates.hbs
@@ -1,5 +1,5 @@
 {{#if this.templatesVisible}}
-  <div class="d-editor-preview">
+  <div class="d-templates">
     <DButton
       class="modal-close close btn-flat"
       @action={{action "hide"}}


### PR DESCRIPTION
This PR removes the `d-editor-preview` class as this is used on a parent's element, and this content does not need that class.