### PR TITLE
UX: add padding to prevent outline cutoff

### DIFF
--- a/assets/stylesheets/discourse-templates.scss
+++ b/assets/stylesheets/discourse-templates.scss
@@ -2,9 +2,9 @@
   .templates-filter-bar {
     display: flex;
     max-width: var(--modal-max-width);
-
     border-bottom: 1px solid var(--primary-low);
     margin-bottom: 1em;
+    padding-top: 1px;
     padding-bottom: 1em;
 
     .select-kit {


### PR DESCRIPTION
Prevent:

![image](https://github.com/discourse/discourse-templates/assets/101828855/3408c475-16b3-42df-9ce4-412bf23df32d)
