### PR TITLE
FIX: Slowness when listing templates and the templates category

### DIFF
--- a/lib/discourse_templates/topic_extension.rb
+++ b/lib/discourse_templates/topic_extension.rb
@@ -28,9 +28,7 @@ module DiscourseTemplates::TopicExtension
     parent_categories_ids = SiteSetting.discourse_templates_categories&.split("|")&.map(&:to_i)
 
     all_templates_categories_ids =
-      parent_categories_ids.flat_map do |category_id|
-        Category.subcategory_ids(category_id).prepend(category_id)
-      end
+      parent_categories_ids.flat_map { |category_id| Category.subcategory_ids(category_id) }
 
     # it is template if the topic belongs to any of the template categories
     return true if all_templates_categories_ids.include?(self.category_id)

--- a/spec/lib/topic_extension_spec.rb
+++ b/spec/lib/topic_extension_spec.rb
@@ -112,5 +112,34 @@ describe DiscourseTemplates::TopicExtension do
         expect(private_template_tag_b.template?(user)).to eq(true)
       end
     end
+
+    it "won't leak state into the Category.subcategory_ids cache" do
+      category = Fabricate(:category_with_definition)
+      subcategory = Fabricate(:category_with_definition, parent_category: category)
+      topic = Fabricate(:template_item, category: subcategory)
+      SiteSetting.discourse_templates_categories = category.id.to_s
+
+      # assert that the return of Category.subcategory_ids is what we expect before
+      # calling template? on the topic
+      expect(Category.subcategory_ids(category.id).size).to eq(2)
+      expect(Category.subcategory_ids(category.id)).to contain_exactly(category.id, subcategory.id)
+
+      expect(topic.template?(user)).to eq(true)
+
+      # the return of Category.subcategory_ids is what was not changed by the call to template?
+      expect(Category.subcategory_ids(category.id).size).to eq(2)
+      expect(Category.subcategory_ids(category.id)).to contain_exactly(category.id, subcategory.id)
+
+      # Now we'll change the category of the topic to a category that is not a template category
+      topic.update!(category: Fabricate(:category))
+
+      # The cache should be invalidated and the topic should no longer be considered a template
+      expect(topic.template?(user)).to eq(false)
+
+      # the return of Category.subcategory_ids is also not changed by the call to template? in a topic
+      # that is not a template
+      expect(Category.subcategory_ids(category.id).size).to eq(2)
+      expect(Category.subcategory_ids(category.id)).to contain_exactly(category.id, subcategory.id)
+    end
   end
 end


### PR DESCRIPTION
Some communities were noticing that fetching the list of templates was very slow.
This issue wouldn't just affect the templates form, but also browsing the templates category and

Most of the communities didn't look like they were affected but in some with extreme cases, this was causing 502 errors.
The problem also seemed intermittent, with the slowness going away completely without any special action.

Upon inspecting a particularly affected instance, the problem was narrowed down to the list of subcategories from the categories templates that was repeating the same `id` multiple times.

The issue was tracked to a line that was mutating an array returned by the method `Category.subcategory_ids` and prepending an item. Unfortunately, the result of this method was cached in the `DistributedCache` and mutating the array was causing the cached value to pile up the same category `id` in the array.

This caused the database queries that used the value returned for this function to become slow over time when the argument was the templates category. The busier the Community, the worst the problem would get.

This commit removes the `prepend` that was causing the issue.