### PR TITLE
UX: shortcut help should show lowercase i

### DIFF
--- a/assets/javascripts/discourse/initializers/d-templates.js
+++ b/assets/javascripts/discourse/initializers/d-templates.js
@@ -70,7 +70,7 @@ function addKeyboardShortcut(api, container) {
         category: "templates",
         name: "templates.insert_template",
         definition: {
-          keys1: [PLATFORM_KEY_MODIFIER, "shift", "I"],
+          keys1: [PLATFORM_KEY_MODIFIER, "shift", "i"],
           keysDelimiter: "plus",
         },
       },


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/43157c39-3e0e-4f53-975d-f8ecb46d939f)

After:
![image](https://github.com/user-attachments/assets/ce63c075-e2de-4823-a886-97324fda1d56)
