### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/assets/javascripts/discourse/connectors/editor-preview/d-templates.hbs
+++ b/assets/javascripts/discourse/connectors/editor-preview/d-templates.hbs
@@ -3,7 +3,7 @@
     <DButton
       class="modal-close close btn-flat"
       @action={{action "hide"}}
-      @icon="times"
+      @icon="xmark"
     />
     <DTemplates::FilterableList
       @onInsertTemplate={{this.onInsertTemplate}}


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.