### PR TITLE
DEV: Add plugin admin title

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,5 +1,7 @@
 en:
   admin_js:
+    discourse_templates:
+      title: "Templates"
     admin:
       site_settings:
         categories:


### PR DESCRIPTION
### What is this change?

This adds a plugin title for the admin sidebar to use.

**Before:**

<img width="246" alt="Screenshot 2025-01-22 at 5 27 59 PM" src="https://github.com/user-attachments/assets/f8e5128c-2f3d-4c8c-bb88-6c09ef8e4f8f" />

**After:**

<img width="195" alt="Screenshot 2025-01-23 at 11 15 12 AM" src="https://github.com/user-attachments/assets/09d5cbb0-9ee2-4aea-97a0-5e18be828c4f" />
