### PR TITLE
FIX: show the modal if the composer has the preview hidden

### DIFF
--- a/assets/javascripts/discourse/services/d-templates.js
+++ b/assets/javascripts/discourse/services/d-templates.js
@@ -10,11 +10,12 @@ export default class DTemplatesService extends Service {
   @service site;
   @service currentUser;
   @service dTemplatesModal;
+  @service composer;
 
   showComposerUI() {
     const onInsertTemplate = this.#insertTemplateIntoComposer.bind(this);
 
-    if (this.site.mobileView) {
+    if (this.site.mobileView || !this.composer.isPreviewVisible) {
       this.#showModal(null, onInsertTemplate); // textarea must be empty when targeting the composer
     } else {
       this.#showComposerPreviewUI(onInsertTemplate);

--- a/test/javascripts/acceptance/templates-test.js
+++ b/test/javascripts/acceptance/templates-test.js
@@ -282,6 +282,24 @@ acceptance("discourse-templates | keyboard shortcut", function (needs) {
     await assertTemplateWasInserted(assert, textarea);
   });
 
+  test("Modal | Templates modal | Show the modal if the preview is hidden", async (assert) => {
+    await visit("/");
+
+    await click("#create-topic");
+    await selectCategory();
+
+    await click(".toggle-preview");
+
+    const textarea = query(".d-editor-input");
+    await textarea.focus();
+
+    await triggerKeyboardShortcut();
+    assert.ok(
+      exists(".d-modal.d-templates"),
+      "It displayed the standard templates modal"
+    );
+  });
+
   test("Modal | Templates modal | Show the modal if a textarea is focused", async (assert) => {
     // if the text area is outside a modal then simply show the insert template modal
     // because there is no need to hijack


### PR DESCRIPTION
Uses the modal if the composer has the preview hidden.

Currently, with the preview closed, the action does nothing.

This is especially important when using the new rich editor.

This will work better with the rich editor once this is also merged: https://github.com/discourse/discourse/pull/32288.