### PR TITLE
DEV: Try fix flaky chat composer spec

### DIFF
--- a/spec/system/chat_composer_spec.rb
+++ b/spec/system/chat_composer_spec.rb
@@ -127,6 +127,7 @@ RSpec.describe "Inserting templates in the chat composer", type: :system do
         chat_page.visit_channel(channel_1)
 
         channel_page.composer.focus # ensure the focus is the textarea
+        expect(channel_page.composer).to be_focused
 
         insert_template_modal.open_with_keyboard_shortcut
         insert_template_modal.open?
@@ -139,6 +140,7 @@ RSpec.describe "Inserting templates in the chat composer", type: :system do
         chat_page.visit_channel(channel_1)
 
         channel_page.composer.focus # ensure the focus is the textarea
+        expect(channel_page.composer).to be_focused
 
         insert_template_modal.open_with_keyboard_shortcut
         insert_template_modal.open?
@@ -154,6 +156,7 @@ RSpec.describe "Inserting templates in the chat composer", type: :system do
         channel_page.reply_to(message_1)
 
         channel_page.composer.focus # ensure the focus is the textarea
+        expect(channel_page.composer).to be_focused
 
         insert_template_modal.open_with_keyboard_shortcut
         insert_template_modal.open?
@@ -210,6 +213,7 @@ RSpec.describe "Inserting templates in the chat composer", type: :system do
         chat_page.visit_thread(message_2.thread)
 
         thread_page.composer.focus # ensure the focus is the textarea
+        expect(thread_page.composer).to be_focused
 
         insert_template_modal.open_with_keyboard_shortcut
         insert_template_modal.open?
@@ -222,6 +226,7 @@ RSpec.describe "Inserting templates in the chat composer", type: :system do
         chat_page.visit_thread(message_2.thread)
 
         thread_page.composer.focus # ensure the focus is the textarea
+        expect(thread_page.composer).to be_focused
 
         insert_template_modal.open_with_keyboard_shortcut
         insert_template_modal.open?

--- a/spec/system/page_objects/modals/insert_template.rb
+++ b/spec/system/page_objects/modals/insert_template.rb
@@ -5,16 +5,18 @@ module PageObjects
     class DTemplatesInsertTemplate < PageObjects::Modals::Base
       include SystemHelpers
 
+      MODAL_SELECTOR = ".d-templates-modal"
+
       def open_with_keyboard_shortcut
         send_keys([PLATFORM_KEY_MODIFIER, :shift, "i"])
       end
 
       def open?
-        super && has_css?(".d-templates-modal") && finished_loading?
+        super && finished_loading?
       end
 
       def finished_loading?
-        has_no_css?(".d-templates-modal .spinner")
+        has_no_css?("#{MODAL_SELECTOR} .spinner")
       end
 
       def select_template(id)


### PR DESCRIPTION
Use proper modal page object selector and check that
the channel composer is focused before sending shortcut
