### PR TITLE
FIX: bug when private template allowed group is everyone

### DIFF
--- a/lib/discourse_templates/user_extension.rb
+++ b/lib/discourse_templates/user_extension.rb
@@ -31,7 +31,7 @@ module DiscourseTemplates::UserExtension
       SiteSetting.discourse_templates_groups_allowed_private_templates&.split("|")&.map(&:to_i)
 
     allowed_groups_ids.any? do |group_id|
-      return false if group_id == 0
+      return true if group_id == Group::AUTO_GROUPS[:everyone]
 
       # the user can use templates if belongs to at least one of the allowed groups
       GroupUser.exists?(group_id: group_id, user_id: self.id)

--- a/spec/lib/user_extension_spec.rb
+++ b/spec/lib/user_extension_spec.rb
@@ -109,6 +109,16 @@ describe DiscourseTemplates::UserExtension do
       expect(user.can_use_private_templates?).to eq(false)
     end
 
+    it "is true when group is 'everyone'" do
+      expect(admin.can_use_private_templates?).to eq(true)
+      expect(moderator.can_use_private_templates?).to eq(true)
+      expect(user.can_use_private_templates?).to eq(false)
+
+      SiteSetting.discourse_templates_groups_allowed_private_templates =
+        Group::AUTO_GROUPS[:everyone].to_s
+      expect(user.can_use_private_templates?).to eq(true)
+    end
+
     it "only returns true to staff or members of the allowed groups" do
       expect(admin.can_use_private_templates?).to eq(true)
       expect(moderator.can_use_private_templates?).to eq(true)


### PR DESCRIPTION
When private template allowed group is everyone, `can_use_private_templates?` method should return true.